### PR TITLE
Minor update to retain numpy test files.

### DIFF
--- a/layers/sklearn/cleanup.sh
+++ b/layers/sklearn/cleanup.sh
@@ -5,6 +5,5 @@ find /tmp/layer/python/ -name "*fortran*.so" -delete
 find /tmp/layer/python/ -name "*.pyc" -delete
 find /tmp/layer/python/ -name "*.dat" -delete
 find /tmp/layer/python/ -path "**/__pycache__/*" -delete
-find /tmp/layer/python/ -path "**/tests/*" -delete
-find /tmp/layer/python/ -path "**/tests/*" -delete
+find /tmp/layer/python/ -path "**/tests/*" -not -path "**/numpy/_core/tests/*" -delete
 find /tmp/layer/python/ -path "**/test/*" -delete


### PR DESCRIPTION
When using the sklearn generated layer on AWS Lambda with Python 3.13, the library was failing to load due to errors: `No module named 'numpy._core.tests._natype'`

These alterations and resolved the issue.